### PR TITLE
Add setting pipe size

### DIFF
--- a/official/player.cpp
+++ b/official/player.cpp
@@ -9,6 +9,11 @@
 #include <cinttypes>
 #include <boost/optional.hpp>
 
+#if defined(__unix__) || defined(__linux__)
+#include <fcntl.h>
+#include <cmath>
+#endif
+
 #include "course.hpp"
 #include "player.hpp"
 
@@ -123,6 +128,26 @@ Player::Player(string command, string name, const RaceCourse &course, int xpos,
   error_code error_code_child;
   unique_ptr<boost::process::ipstream> stderrFromAI(new boost::process::ipstream);
   toAI = unique_ptr<boost::process::opstream>(new boost::process::opstream);
+#if defined(__unix__) || defined(__linux__)
+	{
+		// get native handle of writing
+		const auto sink = toAI->pipe().native_sink();
+		// calucate possible size
+		int psize = 0;
+		const int newline_size = sizeof(toAI->widen('\n'));
+		psize += (int) (std::ceil(std::log10(course.thinkTime)) + 3 + newline_size) * (1 + course.stepLimit);
+		psize += (int) (std::ceil(std::log10(course.stepLimit)) + newline_size) * (1 + course.stepLimit);
+		psize += (int) (std::ceil(std::log10(course.width)) + 1) * (1 + course.stepLimit * 2);
+		psize += (int) (std::ceil(std::log10(course.length)) + newline_size) * (1 + course.stepLimit * 2);
+		psize += (int) (std::ceil(std::log10(course.vision)) + newline_size);
+		psize += (int) (3 * course.width + newline_size) * course.length * course.stepLimit;
+		// set pipe size
+		const auto res = fcntl(sink, F_SETPIPE_SZ, psize);
+		if (res < 0) {
+			std::cerr << __FILE__ << ":" << __LINE__ << " F_SETPIPE_SZ failed... target size : " << psize << std::endl;
+		}
+	}
+#endif
   fromAI = unique_ptr<boost::process::ipstream>(new boost::process::ipstream);
   child = unique_ptr<boost::process::child>(new boost::process::child(
     command,


### PR DESCRIPTION
AI が入力を読み込まない際、ある程度のターンが経過した後の
パイプへの書き込み時にブロックしてしまう問題を修正
（unix, linux 環境のみ）

### 問題再現方法

環境によって異なります。

```sh
./official/official samples/sample.crs "yes 0" a "yes 0" b
```

### 参考

```sh
man pipe.7
```

> If a process attempts  to  write  to  a full  pipe  (see below), then write(2) blocks until sufficient data has been read from the pipe to allow the write  to  complete

### 解決方法

`fcntl` の `F_SETPIPE_SZ` コマンドから
サイズを変更した

### 利用時の注意

設定できる最大サイズ `/proc/sys/fs/pipe-max-size` を確認してください。
必要な場合変更してください。

制限ステップ数が最大でコースの長さとして
予選時ではおよそ `612521` bytes 必要です。